### PR TITLE
Fix breaking changes from dependencies and remove urdf-creator

### DIFF
--- a/pybullet_simulation/setup.py
+++ b/pybullet_simulation/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     # url="https://github.com/pypa/sampleproject",
     packages=setuptools.find_packages(),
     install_requires=[
-        "control-libraries>=3.1.0",
+        "control-libraries>=6.0.0",
         "numpy==1.20.2",
         "numba>=0.54.0",
         "scipy>=1.7.1",

--- a/pybullet_zmq/Dockerfile
+++ b/pybullet_zmq/Dockerfile
@@ -4,24 +4,7 @@ FROM ghcr.io/aica-technology/ros2-control-libraries:${ROS_VERSION} as pybullet
 RUN sudo pip3 install pybullet
 
 
-FROM pybullet as urdf-creator
-
-RUN sudo apt-get update && sudo apt-get install -y python3-tk && sudo rm -rf /var/lib/apt/lists/*
-
-WORKDIR /tmp
-USER root
-RUN --mount=type=ssh git clone -b develop \
-    --depth 1 git@github.com:aica-technology/urdf-creator.git ./urdf-creator
-RUN chown -R ${USER}:${USER} ./urdf-creator
-USER ${USER}
-
-WORKDIR /usr/local/src
-RUN sudo mv /tmp/urdf-creator/source/urdf_creator ./urdf-creator
-RUN sudo pip3 install ./urdf-creator
-RUN rm -rf /tmp/urdf-creator
-
-
-FROM urdf-creator as network-interfaces
+FROM pybullet as network-interfaces
 
 WORKDIR /tmp
 RUN git clone -b develop --depth 1 https://github.com/aica-technology/network-interfaces.git && cd network-interfaces && \

--- a/pybullet_zmq/Dockerfile
+++ b/pybullet_zmq/Dockerfile
@@ -7,8 +7,8 @@ RUN sudo pip3 install pybullet
 FROM pybullet as network-interfaces
 
 WORKDIR /tmp
-RUN git clone -b develop --depth 1 https://github.com/aica-technology/network-interfaces.git && cd network-interfaces && \
-  sudo bash install.sh --auto --no-cpp
+RUN git clone -b v1.1.0 --depth 1 https://github.com/aica-technology/network-interfaces.git && \
+    cd network-interfaces && sudo bash install.sh --auto --no-cpp
 RUN rm -rf /tmp/network-interfaces
 
 

--- a/pybullet_zmq/pybullet_zmq/plugins/robot_state_publisher.py
+++ b/pybullet_zmq/pybullet_zmq/plugins/robot_state_publisher.py
@@ -1,5 +1,5 @@
 from network_interfaces.zmq import network
-from state_representation import Parameter, StateType
+from state_representation import Parameter, ParameterType
 
 
 class RobotStatePublisher:
@@ -28,7 +28,7 @@ class RobotStatePublisher:
         """
         joint_state = self._robot.get_joint_state()
         mass = Parameter(self._robot.name + "_mass", self._robot.get_inertia(joint_state.get_positions()),
-                         StateType.PARAMETER_MATRIX)
+                         ParameterType.MATRIX)
         state = network.StateMessage(self._robot.get_ee_link_state(), joint_state,
                                      self._robot.get_jacobian(joint_state.get_positions()), mass)
         network.send_state(state, self._publisher)

--- a/pybullet_zmq/setup.py
+++ b/pybullet_zmq/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
     url="https://github.com/epfl-lasa/simulator-backend/tree/develop/pybullet_zmq",
     packages=setuptools.find_packages(),
     install_requires=[
+        "control-libraries>=6.0.0"
         "pybullet_simulation",
         "network_interfaces>=0.1.0",
         "pyyaml",

--- a/pybullet_zmq/setup.py
+++ b/pybullet_zmq/setup.py
@@ -14,7 +14,6 @@ setuptools.setup(
     url="https://github.com/epfl-lasa/simulator-backend/tree/develop/pybullet_zmq",
     packages=setuptools.find_packages(),
     install_requires=[
-        "control-libraries>=6.0.0"
         "pybullet_simulation",
         "network_interfaces>=0.1.0",
         "pyyaml",

--- a/pybullet_zmq/setup.py
+++ b/pybullet_zmq/setup.py
@@ -14,8 +14,9 @@ setuptools.setup(
     url="https://github.com/epfl-lasa/simulator-backend/tree/develop/pybullet_zmq",
     packages=setuptools.find_packages(),
     install_requires=[
+        "control_libraries>=6.0.0",
         "pybullet_simulation",
-        "network_interfaces>=0.1.0",
+        "network_interfaces>=1.1.0",
         "pyyaml",
     ],
     classifiers=[


### PR DESCRIPTION
A few fixes here, because control libraries updated to 6.0.0 with breaking changes. Will also update the desired versions of other upstream dependencies, once they are available (e.g. [network-interfaces 1.1.0](https://github.com/aica-technology/network-interfaces/pull/16)).

Also removing the urdf-creator as lab members do not have access to it.

@apr600 @Maxime00 @liuyangdh 